### PR TITLE
:sparkles: Enhance commit command with AI-generated message suggestions and clean up configuration

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -31,8 +31,6 @@ jobs:
       uses: codecov/codecov-action@v5.0.7
       with:
         file: coverage.out
-        flags: unittests
-        name: codecov-umbrella
         slug: jasonbirchall/lazycommit
         fail_ci_if_error: true
       env:


### PR DESCRIPTION
Introduce functionality to suggest commit messages using OpenAI's GPT-3.5-turbo model. The updated command now stages diffs, sends them to the OpenAI API for analysis, and proposes multiple commit messages in the emoji format. Users can select a preferred message for committing changes. This enhances the git workflow by offering context-aware commit message generation, potentially improving clarity and consistency in version control logs. Consider that this feature requires an active internet connection and valid OpenAI API credentials stored in the environment variable `OPENAI_TOKEN`.